### PR TITLE
Fix crash on ios due to sqlite3_column_decltype (from original plugin)

### DIFF
--- a/src/ios/SwiftData.swift
+++ b/src/ios/SwiftData.swift
@@ -1426,29 +1426,23 @@ public struct SwiftData {
                     for i: Int32 in 0 ..< columnCount {
                     //for var i: Int32 = 0; i < columnCount; ++i {
                         let columnName = String(cString: sqlite3_column_name(pStmt, i))
-                        if let columnType = String(validatingUTF8: sqlite3_column_decltype(pStmt, i))?.uppercased() {
-                            if let columnValue: AnyObject = getColumnValue(pStmt!, index: i, type: columnType) {
-                                row[columnName] = SDColumn(obj: columnValue)
-                            }
-                        } else {
-                            var columnType = ""
-                            switch sqlite3_column_type(pStmt, i) {
-                            case 1:
-                                columnType = "INTEGER"
-                            case 2:
-                                columnType = "FLOAT"
-                            case 3:
-                                columnType = "TEXT"
-                            case 4:
-                                columnType = "BLOB"
-                            case 5:
-                                columnType = "NULL"
-                            default:
-                                columnType = "NULL"
-                            }
-                            if let columnValue: AnyObject = getColumnValue(pStmt!, index: i, type: columnType) {
-                                row[columnName] = SDColumn(obj: columnValue)
-                            }
+                        var columnType = ""
+                        switch sqlite3_column_type(pStmt, i) {
+                        case 1:
+                            columnType = "INTEGER"
+                        case 2:
+                            columnType = "FLOAT"
+                        case 3:
+                            columnType = "TEXT"
+                        case 4:
+                            columnType = "BLOB"
+                        case 5:
+                            columnType = "NULL"
+                        default:
+                            columnType = "NULL"
+                        }
+                        if let columnValue: AnyObject = getColumnValue(pStmt!, index: i, type: columnType) {
+                            row[columnName] = SDColumn(obj: columnValue)
                         }
                     }
                     resultSet.append(row)

--- a/src/ios/SwiftyJson.swift
+++ b/src/ios/SwiftyJson.swift
@@ -337,7 +337,7 @@ extension JSON : Swift.Collection {
     }
 }
 
-public struct JSONIndex: Comparable, _Incrementable, Equatable {
+public struct JSONIndex: Comparable, Equatable {
 
     let arrayIndex: Int?
     let dictionaryIndex: Dictionary<String, AnyObject>.Index?


### PR DESCRIPTION
Please, include this fix to your repository
Without it plugin doesn't work

https://github.com/cowbell/cordova-plugin-geofence/pull/218/commits/ba804e597e3c155637786e4c2191a79afd24529f

P.S. Thanks to @CLTanuki who found this fix and made this fork working 